### PR TITLE
3.1.0.zip was unziped to opencv-3.1.0

### DIFF
--- a/.travis/install_opencv.sh
+++ b/.travis/install_opencv.sh
@@ -24,7 +24,7 @@ else
 
     wget https://github.com/Itseez/opencv/archive/3.1.0.zip
     unzip 3.1.0.zip
-    cd 3.1.0
+    cd opencv-3.1.0
 
     mkdir build
     cd build


### PR DESCRIPTION
When I executed this installation script, an error occured because 3.1.0.zip was unziped to opencv-3.1.0.
OS: Ubuntu16.04.2 LTS